### PR TITLE
fix(.devcontainer): add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
-# Ensure shell scripts always use LF line endings, even on Windows.
-# Without this, Git's core.autocrlf=true converts LF to CRLF on checkout,
-# which breaks shebangs inside devcontainers (exit code 127).
+# Normalize line endings for all text files (LF in repo, native on checkout).
+* text=auto
+
+# Always use LF for shell scripts, even on Windows checkout.
+# Without this, CRLF breaks shebangs inside devcontainers (exit code 127).
 *.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure shell scripts always use LF line endings, even on Windows.
+# Without this, Git's core.autocrlf=true converts LF to CRLF on checkout,
+# which breaks shebangs inside devcontainers (exit code 127).
+*.sh text eol=lf


### PR DESCRIPTION
Closes #9

## Summary

On Windows, Git default `core.autocrlf=true` converts LF to CRLF on checkout. This causes `post-create.sh` shebang to become `#!/usr/bin/env bash\r`, which Linux cannot resolve (exit code 127).

## Changes

- Add `.gitattributes` with `* text=auto` to normalize line endings across Windows / Mac / Ubuntu
- Add `*.sh text eol=lf` to always force LF for shell scripts, preventing shebang breakage in devcontainers