### PR TITLE
docs(scope): clarify Claude Databricks target (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,56 @@
 # databricks-ai-starter
 
-An integrated development environment template combining Claude Code / Codex CLI / Databricks
+An integrated development environment template combining Claude Code and Databricks.
 
 ## 1. What Makes This Template Powerful
 
-This template provides a seamless AI-assisted development experience with Databricks by integrating two powerful libraries:
+This template provides a seamless AI-assisted development experience with
+Databricks by integrating two powerful libraries:
 
-**jupyter-databricks-kernel** - Execute your entire notebook workload on Databricks clusters without any code changes. Simply select the "Databricks" kernel in VS Code or JupyterLab, and your Python code runs with the full power of Spark and Databricks infrastructure. Works perfectly with CLI automation via `jupyter execute`.
+**jupyter-databricks-kernel** - Execute your entire notebook workload on
+Databricks clusters without any code changes. Simply select the "Databricks"
+kernel in VS Code or JupyterLab, and your Python code runs with the full power
+of Spark and Databricks infrastructure. Works perfectly with CLI automation via
+`jupyter execute`.
 
-**mcp-databricks-server** - Enable AI assistants (Claude Code, Codex CLI) to directly query your Databricks data and explore Unity Catalog metadata. AI can execute SQL, inspect table schemas, view lineage, and answer questions about your data - all through natural language. Built-in safety mechanisms prevent destructive operations.
+**mcp-databricks-server** - Enable Claude Code to directly query your Databricks
+data and explore Unity Catalog metadata. Claude can execute SQL, inspect table
+schemas, view lineage, and answer questions about your data - all through
+natural language. Built-in safety mechanisms prevent destructive operations.
 
-Together, these components create a development environment where AI assistants can understand your data warehouse structure, execute queries, and help you write data transformation code that runs on production-grade infrastructure.
+Together, these components create a development environment where AI assistants
+can understand your data warehouse structure, execute queries, and help you
+write data transformation code that runs on production-grade infrastructure.
 
-## 2. Quick Start
+## 2. Reference Alignment Scope
 
-1. Open in GitHub Codespaces, or start with "Reopen in Container" in VS Code Dev Container
+This starter follows the reusable engineering shape of
+<https://github.com/genda-tech/databricks-ai-starter> for development-container
+structure, dependency management, bootstrap guardrails, and concise maintainer
+workflow. That repository is an engineering reference, not a content source for
+this public template.
+
+The public starter targets Claude Code plus Databricks. Codex is not a
+supported target for this alignment track. Tool packaging should be owned by Dev
+Container Features, and later setup work should remove `mise` as a required
+tool-installation surface.
+
+Private or domain-specific analytics knowledge is excluded by default. If
+examples are added, they must be synthetic or sanitized and must not copy
+private catalogs, reports, notebooks, credentials, paths, or business rules from
+the reference repository.
+
+## 3. Quick Start
+
+1. Open in GitHub Codespaces, or start with "Reopen in Container" in VS Code
+   Dev Container
 2. Edit `.databrickscfg` to configure authentication credentials
 3. Set `DATABRICKS_CONFIG_PROFILE` in `.env`
-4. Launch `claude` or `codex` from the terminal
+4. Launch `claude` from the terminal
 
-## 3. Authentication Configuration
+## 4. Authentication Configuration
 
-### 3.1. `.databrickscfg`
+### 4.1. `.databrickscfg`
 
 For Service Principal:
 
@@ -44,23 +73,25 @@ warehouse_id = your-warehouse-id
 cluster_id = your-cluster-id
 ```
 
-### 3.2. `.env`
+### 4.2. `.env`
 
 ```bash
 export DATABRICKS_CONFIG_PROFILE=databricks-workspace-1
 ```
 
-## 4. Jupyter Notebook
+## 5. Jupyter Notebook
 
-In Jupyter Notebook, selecting the "Databricks" kernel enables remote execution.
+In Jupyter Notebook, selecting the "Databricks" kernel enables remote
+execution.
 
-For the first launch in GitHub Codespaces, the "Databricks" kernel will appear after an F5 reload.
+For the first launch in GitHub Codespaces, the "Databricks" kernel will appear
+after an F5 reload.
 
-## 5. Components
+## 6. Components
 
 This template includes the following components:
 
-### 5.1. jupyter-databricks-kernel
+### 6.1. jupyter-databricks-kernel
 
 A Jupyter kernel for complete remote execution on Databricks clusters.
 
@@ -70,7 +101,7 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
 
 Repository: <https://github.com/i9wa4/jupyter-databricks-kernel>
 
-### 5.2. mcp-databricks-server
+### 6.2. mcp-databricks-server
 
 MCP server for executing SQL queries on Databricks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "databricks-ai-starter"
 version = "0.1.0"
-description = "Dev Container starter template for AI assistants (Claude Code, Codex CLI) with Databricks"
+description = "Dev Container starter template for Claude Code with Databricks"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Clarifies that this starter targets Claude Code plus Databricks.
- Records the genda-tech starter as an engineering reference, not a source for private domain content.
- Removes Codex from public package metadata.

## Verification
- `git diff --check`
- `nix run nixpkgs#rumdl -- check README.md`
- `python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("pyproject.toml").read_text())'`
- Changed-file scan for local machine paths

Closes #11
